### PR TITLE
Create docker-compose.yaml

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,8 @@
+services:
+  archipelago-server:
+    build: .
+    ports:
+      - "80:80"
+    volumes:
+      - "./archipelago:/archipelago"
+      - "./baseroms:/baseroms"


### PR DESCRIPTION
Very basic docker-compose.yaml to deploy from within folder. Hosted image required to target image instead of cloning the repository.